### PR TITLE
OBS websocket integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![IMAGE ALT TEXT HERE](https://img.youtube.com/vi/fbshqualaJc/0.jpg)](https://www.youtube.com/watch?v=fbshqualaJc)
 
-hate5sync is a dumb algorithm used to calculate the necessary offset for syncing separate audio/video sources in OBS. Play slate.mp4 on a device (ie your phone) pointed at the camera and microphone and record it within OBS. Let's call that recorded file <b>claptest.mp4</b>. For best results, cover the entire camera lens with the phone and minimize background noise. <b>Any light leaks or things besides the full black screen will trip the visual peak detector.</b> Run this script on claptest.mp4 and it will calculate the offset between the visual and acoustic peaks. Enter that value into the OBS "sync offset" field and you're done. Click the image above to watch a demo.
+hate5sync is a dumb algorithm used to calculate the necessary offset for syncing separate audio/video sources in OBS. Play slate.mp4 on a device (ie your phone) pointed at the camera and microphone and record it within OBS. Let's call that recorded file <b>claptest.mp4</b>. For best results, cover the entire camera lens with the phone and minimize background noise. <b>Any light leaks or things besides the full black screen will trip the visual peak detector.</b> Run this script on claptest.mp4 and it will calculate the offset between the visual and acoustic peaks. The app uses OBS websockets to automatically update the offset field. Click the image above to watch a demo.
 
 <h2>Installation:</h2>
 
@@ -13,6 +13,9 @@ The following dependencies are required:
   <li><a href="https://github.com/kkroening/ffmpeg-python" target="_blank">ffmpeg</a> </li>
   <li><a href="https://numpy.org/" target="_blank">numpy</a> </li>
   <li><a href="http://easygui.sourceforge.net/" target="_blank">easygui</a> </li>
+  <li><a href="https://github.com/obsproject/obs-websocket" target="_blank">obs-websocket server</a> </li>
+  <li><a href="https://github.com/Elektordi/obs-websocket-py" target="_blank">obs-websocket Python library</a> </li>
+  
 </ul> 
 
 Or you can just use the requirements.txt file
@@ -23,16 +26,34 @@ or
 ```
 conda create --name <env_name> --file requirements.txt
 ```
+
+The latest version of the app automatically updates the sync offset field through OBS websockets. You will need to download OBS websockets from the link above and follow the installation instructions carefully. With OBS running, you can now run hate5sync and it will communicate directly with OBS.
+
 <h2>Running hate5sync:</h2>
 
-You can run hate5sync by pointing it to the recorded video:
+You can run hate5sync with the following arguments:
 ```
-python hate5sync.py --infile path_to_recorded_video
+usage: hate5sync.py [-h] [--infile INFILE] [--dir DIR] [--host HOST] [--port PORT] [--pw PW] [--src SRC]
+
+hate5sync
+
+options:
+  -h, --help       show this help message and exit
+  --infile INFILE  path to file
+  --dir DIR        path to directory
+  --host HOST      OBS websocket host
+  --port PORT      OBS websocket port
+  --pw PW          OBS websocket password
+  --src SRC        OBS source name to be offset
+  ```
+You can use --infile to pass in the video file recorded in OBS. If a file is not passed in the app will take the most recent file specified in --dir. If --dir is not set it will retrieve the default OBS recording directory. If you are not using the default host/port/password for OBS websockets, use the corresponding options to override the defaults. --src should be the name of source in OBS that needs the offset applied. If this option is not set you will be presented with a dialog box asking you to choose.
+
+For example, running
 ```
-Alternatively, if you are recording videos with OBS (as shown in the demo), you can just point hate5sync to the default OBS video recording directory and it will automatically read the most recent file:
+python -i hate5sync.py --pw password --src "Mic/Aux"
 ```
-python hate5sync.py --dir path_to_OBS_video_directory
-```
+
+Will retrieve the latest file recorded in OBS using, compute the delay, then automatically set the offset to the Mic/Aux source.
 
 Personally I save the latter line to a file called <b>hate5sync.bat</b> and assign to a button via StreamDeck:<br><br>
 ![Alt text](demo/streamdeck.png?raw=true "streamdeck")
@@ -45,15 +66,14 @@ First it loads claptest.mp4
 video_stream = cv2.VideoCapture(video_file)
 fps = video_stream.get(cv2.CAP_PROP_FPS)
 ```  
-Then it loops over the video frame by frame. We use open-cv to convert each frame to the LAB colorspace. All we care about the L channel, which captures lightness (intensity). L ends up being a matrix the size of the video frame (1920x1080). We normalize it so each value in the matrix is between 0-1. Then we compute the average value of that normalized matrix to get the average brightness of that image. Store that in a list called <b>brightness</b> and repeat the process on the next frame.
+Then it loops over the video frame by frame. We use open-cv to convert each frame to the LAB colorspace. All we care about the L channel, which captures lightness (intensity). L ends up being a matrix the size of the video frame (1920x1080). Then we compute the average value of that normalized matrix to get the average brightness of that image. Store that in a list called <b>brightness</b> and repeat the process on the next frame.
 ```
 success,image = video_stream.read()
 brightness = []
 
 while success:
   L, A, B = cv2.split(cv2.cvtColor(image, cv2.COLOR_BGR2LAB))
-  L_norm = L/np.max(L)
-  L_mean = np.mean(L_norm)
+  L_mean = np.mean(L)
   brightness.append(L_mean)
   success,image= video_stream.read()
 ```    
@@ -61,11 +81,9 @@ while success:
 If we plot the values stored in <b>brightness</b> we get something that looks like<br>
 ![Alt text](demo/brightness.png?raw=true "Brightness vs frame")
 
-We could look for the max brightness value, but quick tests indicate that finding the max change in brightness is more accurate. It makes sense: if you look at the above plot the peak isn't a sharp point, it spikes up then increases for a few frames before dropping down. We care about the initial jump. For each consecutive brightness values we'll compute the successive differences, then find the frame that contained the biggest jump:
-
+Next, we find the frame with the maximum brightness, which should correspond to the moment the flash appears on screen:
 ```
-pairs_bright = list(((b-a) for a,b in zip(brightness, brightness[1:])))
-peak_video = np.argmin(pairs_bright)
+peak_video = np.argmax(brightness)
 ```
 
 The audio portion is even dumber. First we'll use ffmpeg to extract the audio from claptest.mp4 and store it to a temporary wav file:
@@ -89,9 +107,9 @@ peak_audio = fps*np.argmax(y)/sr
 Overlaying the data we get something like this<br>
 ![Alt text](demo/delay.png?raw=true "amplitude and brightness peaks")
 
-Finally, we take the difference between the peaks (as frames), divide it by the framerate to get the difference in seconds, then convert to milliseconds
+Finally, we take the difference between the peaks (as frames), divide it by the framerate to get the difference in seconds:
 ```
-delay = 1000*(max(peak_audio, peak_video) - min(peak_video, peak_audio))/fps
+delay = (peak_video - peak_audio)/fps
 ```
 <br>
-Game over. Enter that value into OBS' "sync offset" feature and now your audio/video sources are pretty damn close lmao.
+That delay is then automatically applied to the specified source in OBS.

--- a/hate5sync.py
+++ b/hate5sync.py
@@ -91,7 +91,7 @@ if __name__ == '__main__':
 			rec_folder = folder.getRecFolder()
 
 		# get the most recent video file from the dir
-		list_of_files = glob.glob(os.path.join(args.dir, "*")) 
+		list_of_files = glob.glob(os.path.join(rec_folder, "*")) 
 		video_file = max(list_of_files, key=os.path.getctime)
 
 	# if OBS source name is set, use it

--- a/hate5sync.py
+++ b/hate5sync.py
@@ -6,6 +6,14 @@ import ffmpeg
 import numpy as np
 import easygui
 import argparse
+import sys
+import time
+
+import logging
+logging.basicConfig(level=logging.INFO)
+
+sys.path.append('../')
+from obswebsocket import obsws, requests  # noqa: E402
 
 def compute_video_peak(video_file):
 	"""Detect when the sync video flashes."""
@@ -24,21 +32,15 @@ def compute_video_peak(video_file):
 		# split image to LAB colorspace. L captures lightness (intensity)
 		L, A, B = cv2.split(cv2.cvtColor(image, cv2.COLOR_BGR2LAB))
 
-		# normalize L channel to be between 0-1
-		L_norm = L/np.max(L)
-
 		# compute the average brightness of the normalized L channel
-		L_mean = np.mean(L_norm)
+		L_mean = np.mean(L)
 
 		# store the average brightness and read the next video frame
 		brightness.append(L_mean)
 		success,image= video_stream.read()
 	
-	# compute successive brightness difference between consecutive frames
-	pairs_bright = list(((b-a) for a,b in zip(brightness, brightness[1:])))
-
-	# find the frame consisting the biggest change in brightness
-	peak_video = np.argmin(pairs_bright)
+	# find the brightest frame
+	peak_video = np.argmax(brightness)
 
 	return (fps, peak_video)
 
@@ -61,25 +63,61 @@ def compute_audio_peak(video_file, fps):
 	return peak_audio
 	
 if __name__ == '__main__':
+
 	parser = argparse.ArgumentParser(description='hate5sync')
 	parser.add_argument('--infile', help="path to file")
 	parser.add_argument('--dir', help="path to directory")
+	parser.add_argument('--host', default="localhost", help="OBS websocket host")
+	parser.add_argument('--port', type=int, default=4444, help="OBS websocket port")
+	parser.add_argument('--pw', default="secret", help="OBS websocket password")
+	parser.add_argument('--src', help="OBS source name to be offset")
 	args = parser.parse_args()
 
+	# connect to OBS websocket
+	ws = obsws(args.host, args.port, args.pw)
+	ws.connect()
+
+	# if recorded file is passed in, use it
 	if args.infile:
 		video_file = args.infile
-	elif args.dir:
+	else:
+		# if recording dir is passed in, use it
+		if args.dir:
+			rec_folder = args.dir
+
+		# otherwise get the recording dir from OBS
+		else:
+			folder = ws.call(requests.GetRecordingFolder())
+			rec_folder = folder.getRecFolder()
+
+		# get the most recent video file from the dir
 		list_of_files = glob.glob(os.path.join(args.dir, "*")) 
 		video_file = max(list_of_files, key=os.path.getctime)
-	
+
+	# if OBS source name is set, use it
+	if args.src:
+		src = args.src
+
+	# else prompt the user to choose the source to be offset
+	else:
+		msg = "Choose the OBS Source to be offset"
+		title = "OBS Source List"
+		source_list = ws.call(requests.GetSourcesList())
+		sources = [s['name'] for s in source_list.getSources()]
+		src = easygui.choicebox(msg, title, sources)
+
+	# compute the video peak
 	(fps, peak_video) = compute_video_peak(video_file)
+
+	# compute the audio peak
 	peak_audio = compute_audio_peak(video_file, fps)
 
-	# find the difference in audio/video peaks and convert to milliseconds
-	delay = 1000*(peak_video - peak_audio)/fps
-	if delay > 0:
-		easygui.msgbox("Audio is ahead. Delay it by %.2f milliseconds" % delay)
-	elif delay < 0:
-		easygui.msgbox("Video is ahead. Delay it by %.2f milliseconds" % abs(delay))
-	else:
-		easygui.msgbox("No sync offset needed.")
+	# find the difference in seconds between audio/video peaks
+	delay = (peak_video - peak_audio)/fps
+
+	# automatically update the source to the computed delay (in nanoseconds)
+	ws.call(requests.SetSyncOffset(src, delay*1000000000))
+	easygui.msgbox("A delay of %.2f ms has been applied to %s" % (delay*1000, src))
+
+	# disconnect from websocket
+	ws.disconnect()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
-easygui==0.98.3
-ffmpeg==1.4
-ffmpeg_python==0.2.0
-librosa==0.9.1
-numpy==1.21.2
-opencv_python==4.5.5.62
+numpy==1.22.3
+easygui=0.98.1=py310h5588dad_3
+ffmpeg=4.3.1=ha925a31_0
+ffmpeg-python=0.2.0=py_0
+librosa=0.9.1=pyhd8ed1ab_0
+obs-websocket-py=0.5.3=pypi_0
+opencv=4.5.4=py310hc26a207_3


### PR DESCRIPTION
**Changelog**

- using OBS websockets to automatically apply the computed delay to the appropriate source
- if src option is not supplied a dialog box prompts the user to choose from the sources available in OBS
- no longer normalizing the L matrix (unnecessary computation)
- using np.argmax instead of np.argmin (scrapping an edge case in favor of readability)